### PR TITLE
Fix version leading, trailing whitespae

### DIFF
--- a/androidlinstaller.sh
+++ b/androidlinstaller.sh
@@ -24,6 +24,9 @@ fi
 # Extract the last version number
 version=$(echo "$metadata" | grep "<version>" | tail -n 1 | sed -n 's|\s*<version>\(.*\)</version>|\1|p')
 
+version="${version#${version%%[![:space:]]*}}"   # remove leading whitespace characters
+version="${version%${version##*[![:space:]]}}"   # remove trailing whitespace characters
+
 # Create the jar url
 android_jar_url=$ANDROID_LINTER_RELEASE_URL/$version/$ANDROID_JAR_FILE_NAME-$version.jar
 


### PR DESCRIPTION
In OS X, I have to trim the version variable, otherwise will return "      1.1.18"